### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,12 +12,11 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 27
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
I am getting some build errors due to compileSdk being so low:

```Execution failed for task ':react-native-ping:verifyReleaseResources'.
> java.util.concurrent.ExecutionException: com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
 error: resource android:style/TextAppearance.Material.Widget.Button.Borderless.Colored not found.
 error: resource android:style/TextAppearance.Material.Widget.Button.Colored not found.
 /Users/adriantache/Documents/React_Projects/prowallet/node_modules/react-native-ping/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:7: error: resource android:attr/colorError not found.
 /Users/adriantache/Documents/React_Projects/prowallet/node_modules/react-native-ping/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:11: error: resource android:attr/colorError not found.
 /Users/adriantache/Documents/React_Projects/prowallet/node_modules/react-native-ping/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:15: error: style attribute 'android:attr/keyboardNavigationCluster' not found.
 /Users/adriantache/Documents/React_Projects/prowallet/node_modules/react-native-ping/android/build/intermediates/res/merged/release/values/values.xml:1956: error: resource android:attr/fontStyle not found.
 /Users/adriantache/Documents/React_Projects/prowallet/node_modules/react-native-ping/android/build/intermediates/res/merged/release/values/values.xml:1956: error: resource android:attr/font not found.
 /Users/adriantache/Documents/React_Projects/prowallet/node_modules/react-native-ping/android/build/intermediates/res/merged/release/values/values.xml:1956: error: resource android:attr/fontWeight not found.
 error: failed linking references.```