### PR TITLE
Update React Native dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "author": "tiancailuohao@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2 || ^0.57.0"
+    "react-native": "^0.41.2 || ^0.57.0 || ^0.68.0"
   }
 }


### PR DESCRIPTION
closes #91 

While trying to install the library, I was also getting the errors mentioned in #91. This PR change should fix it & the library shall work again with the latest react native versions.